### PR TITLE
Revert "Modified: Blockscout Hyperlinks"

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_footer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_footer.html.eex
@@ -21,11 +21,14 @@
       <div class="col-xs-12 col-lg-3">
         <p class="footer-info-text"><%= gettext("Blockscout is a tool for inspecting and analyzing EVM based blockchains. Blockchain explorer for Ethereum Networks.") %></p>
         <div class="footer-social-icons">
-          <a href="<%= "https://github.com/neobase-one/canto-blockscout" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Github") %>'>
+          <a href="<%= Application.get_env(:block_scout_web, :footer)[:github_link] %>" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Github") %>'>
             <div class="footer-social-icon-container fontawesome-icon github"></div>
           </a>
-          <a href="https://twitter.com/NeoBase_Studios" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Twitter") %>'>
+          <a href="https://www.twitter.com/blockscoutcom/" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Twitter") %>'>
             <div class="footer-social-icon-container fontawesome-icon twitter"></div>
+          </a>
+          <a href="https://t.me/poa_network" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Telegram") %>'>
+            <div class="footer-social-icon-container fontawesome-icon telegram"></div>
           </a>
         </div>
       </div>
@@ -33,9 +36,10 @@
       <div class="col-xs-12 col-md-4 col-lg-<%= col_size %> footer-list">
         <h3>BlockScout</h3>
         <ul>
-          <li><a href="https://github.com/neobase-one/canto-blockscout" rel="noreferrer" class="footer-link" target="_blank"><%= gettext("Submit an Issue") %></a></li>
-          <li><a href="https://github.com/neobase-one/canto-blockscout" rel="noreferrer" class="footer-link"><%= gettext("Contribute") %></a></li>
-          <li><a href="https://github.com/neobase-one/canto-blockscout" rel="noreferrer" class="footer-link"><%= gettext("Forum") %></a></li>
+          <li><a href="<%= issue_link(@conn) %>" rel="noreferrer" class="footer-link" target="_blank"><%= gettext("Submit an Issue") %></a></li>
+          <li><a href="<%= Application.get_env(:block_scout_web, :footer)[:github_link] %>" rel="noreferrer" class="footer-link"><%= gettext("Contribute") %></a></li>
+          <li><a href="<%= Application.get_env(:block_scout_web, :footer)[:chat_link] %>" rel="noreferrer" class="footer-link"><%= gettext("Chat (#blockscout)") %></a></li>
+          <li><a href="<%= Application.get_env(:block_scout_web, :footer)[:forum_link] %>" rel="noreferrer" class="footer-link"><%= gettext("Forum") %></a></li>
           <%= if System.get_env("COIN_NAME") && System.get_env("NETWORK_PATH") && System.get_env("SUBNETWORK") && System.get_env("JSON_RPC") && System.get_env("CHAIN_ID") do %>
             <li><a class="footer-link js-btn-add-chain-to-mm btn-add-chain-to-mm in-footer" style="cursor: pointer;"><%= gettext("Add") <> " #{System.get_env("SUBNETWORK")}" %></a></li>
           <% end %>


### PR DESCRIPTION
Reverts neobase-one/canto-blockscout#1

- due to compilation error

# Replicating Error
## Command
```sh
mix do deps.get, local.rebar --force, deps.compile, compile 
```
## Error
```
== Compilation error in file lib/block_scout_web/views/layout_view.ex ==
** (TokenMissingError) lib/block_scout_web/templates/layout/_footer.html.eex:24:163: missing terminator: ' (for string starting at line 24)
    |
 24 |  "https://github.com/neobase-one/canto-blockscout" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Github") 
    |                                                                                                                                             ^
    (eex 1.13.4) lib/eex/compiler.ex:60: EEx.Compiler.generate_buffer/4
    (phoenix 1.5.13) lib/phoenix/template.ex:352: Phoenix.Template.compile/3
    (phoenix 1.5.13) lib/phoenix/template.ex:167: anonymous fn/4 in Phoenix.Template."MACRO-__before_compile__"/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (phoenix 1.5.13) expanding macro: Phoenix.Template.__before_compile__/1
    lib/block_scout_web/views/layout_view.ex:1: BlockScoutWeb.LayoutView (module)
```

# How to test
- setup local Postgres instance 
  - [How to Create SuperUser in postgres](https://chartio.com/resources/tutorials/how-to-change-a-user-to-superuser-in-postgresql/)
- follow this [Tutorial](https://wiki.polygon.technology/docs/edge/additional-features/blockscout/)